### PR TITLE
Add a conditional gradient to categories

### DIFF
--- a/src/components/Categories.js
+++ b/src/components/Categories.js
@@ -11,7 +11,7 @@ export const Categories = ({ categories }) => {
   const [viewWidth, setViewWidth] = useState(0);
 
   useEffect(() => {
-    setShowGradient(scrollViewContentWidth > viewWidth);
+    setShowGradient(scrollViewContentWidth > (viewWidth + 3));
   }, [scrollViewContentWidth, viewWidth]);
 
   return (


### PR DESCRIPTION
On homescreen, when categories container is wide enough to require scrolling, add a gradient, fade to white, to indicate to the user that there are more categories to view.