### PR TITLE
Fix notifications

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -136,12 +136,12 @@ export default function App() {
                 <Stack.Group screenOptions={{ headerShown: false, presentation: 'modal' }}>
                   <Stack.Screen
                     component={CreateWordlistEntriesScreen}
-                    initialParams={{ presentation: 'modal' }}
+                    initialParams={{ isModal: true }}
                     name='CreateWordlistEntries'
                   />
                   <Stack.Screen
                     component={EditWordlistEntryScreen}
-                    initialParams={{ presentation: 'modal' }}
+                    initialParams={{ isModal: true }}
                     name='EditWordlistEntry'
                   />
                 </Stack.Group>

--- a/App.tsx
+++ b/App.tsx
@@ -7,7 +7,6 @@ import { getMainDefinition } from '@apollo/client/utilities';
 import { loadDevMessages } from '@apollo/client/dev';
 import { MY_WORDLIST_GRAPHQL_URL } from '@env';
 import { NavigationContainer } from '@react-navigation/native';
-import { NotificationProvider } from './src/components';
 import { removeTypename } from './src/utils/removeTypename';
 import type { RootStackParamList } from './types';
 import { StatusBar } from 'expo-status-bar';
@@ -101,51 +100,54 @@ export default function App() {
       <ErrorBoundary FallbackComponent={Error}>
         <ApolloProvider client={client}>
           <PaperProvider theme={theme}>
-            <NotificationProvider>
-              <NavigationContainer>
-                <Stack.Navigator
-                  screenOptions={{
-                    header: props => <NavigationBar {...props} />
-                  }}
-                >
-                  <Stack.Group>
-                    <Stack.Screen
-                      component={HomeScreen}
-                      name='Home'
-                      options={{ title: 'My Wordlist' }}
-                    />
-                    <Stack.Screen
-                      component={LogInScreen}
-                      name='LogIn'
-                      options={{ title: 'My Wordlist' }}
-                    />
-                    <Stack.Screen
-                      component={SignUpScreen}
-                      name='SignUp'
-                      options={{ title: 'My Wordlist' }}
-                    />
-                    <Stack.Screen
-                      component={ForgotYourPasswordScreen}
-                      name='ForgotYourPassword'
-                      options={{ title: 'My Wordlist' }}
-                    />
-                    <Stack.Screen
-                      component={GenerateExampleSentencesScreen}
-                      name='GenerateExampleSentences'
-                      options={{ title: 'My Wordlist' }}
-                    />
-                  </Stack.Group>
-                  <Stack.Group screenOptions={{ headerShown: false, presentation: 'modal' }}>
-                    <Stack.Screen
-                      component={CreateWordlistEntriesScreen}
-                      name='CreateWordlistEntries'
-                    />
-                    <Stack.Screen component={EditWordlistEntryScreen} name='EditWordlistEntry' />
-                  </Stack.Group>
-                </Stack.Navigator>
-                <StatusBar style='auto' />
-              </NavigationContainer>
-            </NotificationProvider>
+            <NavigationContainer>
+              <Stack.Navigator
+                screenOptions={{
+                  header: props => <NavigationBar {...props} />
+                }}
+              >
+                <Stack.Group>
+                  <Stack.Screen
+                    component={HomeScreen}
+                    name='Home'
+                    options={{ title: 'My Wordlist' }}
+                  />
+                  <Stack.Screen
+                    component={LogInScreen}
+                    name='LogIn'
+                    options={{ title: 'My Wordlist' }}
+                  />
+                  <Stack.Screen
+                    component={SignUpScreen}
+                    name='SignUp'
+                    options={{ title: 'My Wordlist' }}
+                  />
+                  <Stack.Screen
+                    component={ForgotYourPasswordScreen}
+                    name='ForgotYourPassword'
+                    options={{ title: 'My Wordlist' }}
+                  />
+                  <Stack.Screen
+                    component={GenerateExampleSentencesScreen}
+                    name='GenerateExampleSentences'
+                    options={{ title: 'My Wordlist' }}
+                  />
+                </Stack.Group>
+                <Stack.Group screenOptions={{ headerShown: false, presentation: 'modal' }}>
+                  <Stack.Screen
+                    component={CreateWordlistEntriesScreen}
+                    initialParams={{ presentation: 'modal' }}
+                    name='CreateWordlistEntries'
+                  />
+                  <Stack.Screen
+                    component={EditWordlistEntryScreen}
+                    initialParams={{ presentation: 'modal' }}
+                    name='EditWordlistEntry'
+                  />
+                </Stack.Group>
+              </Stack.Navigator>
+              <StatusBar style='auto' />
+            </NavigationContainer>
           </PaperProvider>
         </ApolloProvider>
       </ErrorBoundary>

--- a/App.tsx
+++ b/App.tsx
@@ -136,9 +136,14 @@ export default function App() {
                 <Stack.Group screenOptions={{ headerShown: false, presentation: 'modal' }}>
                   <Stack.Screen
                     component={CreateWordlistEntriesScreen}
+                    initialParams={{ presentation: 'modal' }}
                     name='CreateWordlistEntries'
                   />
-                  <Stack.Screen component={EditWordlistEntryScreen} name='EditWordlistEntry' />
+                  <Stack.Screen
+                    component={EditWordlistEntryScreen}
+                    initialParams={{ presentation: 'modal' }}
+                    name='EditWordlistEntry'
+                  />
                 </Stack.Group>
               </Stack.Navigator>
               <StatusBar style='auto' />

--- a/App.tsx
+++ b/App.tsx
@@ -136,14 +136,9 @@ export default function App() {
                 <Stack.Group screenOptions={{ headerShown: false, presentation: 'modal' }}>
                   <Stack.Screen
                     component={CreateWordlistEntriesScreen}
-                    initialParams={{ presentation: 'modal' }}
                     name='CreateWordlistEntries'
                   />
-                  <Stack.Screen
-                    component={EditWordlistEntryScreen}
-                    initialParams={{ presentation: 'modal' }}
-                    name='EditWordlistEntry'
-                  />
+                  <Stack.Screen component={EditWordlistEntryScreen} name='EditWordlistEntry' />
                 </Stack.Group>
               </Stack.Navigator>
               <StatusBar style='auto' />

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ SIGN_UP_URL=http://localhost:3001/api/signup
 
 Hardcode the following values into the code instead of relying on the values being pulled from `.env.development`:
 `MY_WORDLIST_GRAPHQL_URL`: `'http://10.0.2.2:3000/graphql'`
-`RESET_PASSWORD_URL`: `http://10.0.2.2:3001/api/reset-password`
+`RESET_PASSWORD_URL`: `'http://10.0.2.2:3001/api/reset-password'`
 `SIGN_IN_URL`: `'http://10.0.2.2:3001/api/signin'`
 `SIGN_UP_URL`: `'http://10.0.2.2:3001/api/signup'`
 

--- a/__tests__/journeys/AddFiltersJourney.test.js
+++ b/__tests__/journeys/AddFiltersJourney.test.js
@@ -5,7 +5,6 @@ import { HomeScreen } from '../../src/screens';
 import { MockedProvider } from '@apollo/client/testing';
 import { myWordlistQueryMock } from '../../mockedProviderMocks';
 import { NavigationContainer } from '@react-navigation/native';
-import { NotificationProvider } from '../../src/components';
 import { Provider as PaperProvider } from 'react-native-paper';
 import { parseUniqueCategories } from '../../src/utils/parseUniqueCategories';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react-native';
@@ -28,13 +27,15 @@ describe('Filtering', () => {
       render(
         <PaperProvider>
           <MockedProvider addTypename={true} mocks={[myWordlistQueryMock]}>
-            <NotificationProvider>
-              <NavigationContainer>
-                <Stack.Navigator>
-                  <Stack.Screen component={HomeScreen} name="Home" options={{ title: 'My Wordlist' }} />
-                </Stack.Navigator>
-              </NavigationContainer>
-            </NotificationProvider>
+            <NavigationContainer>
+              <Stack.Navigator>
+                <Stack.Screen
+                  component={HomeScreen}
+                  name='Home'
+                  options={{ title: 'My Wordlist' }}
+                />
+              </Stack.Navigator>
+            </NavigationContainer>
           </MockedProvider>
         </PaperProvider>
       );
@@ -44,7 +45,9 @@ describe('Filtering', () => {
   afterEach(() => jest.clearAllMocks());
 
   test('filters is not initially visible', async () => {
-    await waitFor(() => expect(screen.queryByText('Select categories to include:')).not.toBeOnTheScreen());
+    await waitFor(() =>
+      expect(screen.queryByText('Select categories to include:')).not.toBeOnTheScreen()
+    );
   });
 
   describe('after tapping open filters button', () => {
@@ -56,30 +59,46 @@ describe('Filtering', () => {
     });
 
     test('filters drawer is visible', async () => {
-      await waitFor(() => expect(screen.getByText('Select categories to include:')).toBeOnTheScreen());
+      await waitFor(() =>
+        expect(screen.getByText('Select categories to include:')).toBeOnTheScreen()
+      );
     });
 
     test('open-filters button is unchecked', async () => {
-      await waitFor(() => expect(screen.getByTestId('open-filters-button-unchecked')).toBeOnTheScreen());
+      await waitFor(() =>
+        expect(screen.getByTestId('open-filters-button-unchecked')).toBeOnTheScreen()
+      );
       await waitFor(() => expect(screen.queryByTestId('open-filters-button-checked')).toBeNull());
     });
 
-    test.each(wordlistUniqueCategories)('category "%s" is visible within the filters container', async category => {
-      await waitFor(() => {
-        const filtersContainer = screen.getByTestId('filters-container');
-        expect(within(filtersContainer).getByText(category)).toBeVisible();
-      });
-    });
+    test.each(wordlistUniqueCategories)(
+      'category "%s" is visible within the filters container',
+      async category => {
+        await waitFor(() => {
+          const filtersContainer = screen.getByTestId('filters-container');
+          expect(within(filtersContainer).getByText(category)).toBeVisible();
+        });
+      }
+    );
 
     describe('after selecting "adjective" category', () => {
-      const expectedVisibleWords = ['constructive', 'arterial', 'honourable', 'admirable', 'disorderly', 'foolish', 'understated'];
+      const expectedVisibleWords = [
+        'constructive',
+        'arterial',
+        'honourable',
+        'admirable',
+        'disorderly',
+        'foolish',
+        'understated'
+      ];
       let isAdjectiveCategorySelected;
       beforeEach(async () => {
         if (isAdjectiveCategorySelected) return;
         await waitFor(() => {
           fireEvent.press(
-            within(screen.getByTestId('filters-container'))
-              .getByRole('button', { name: 'adjective' })
+            within(screen.getByTestId('filters-container')).getByRole('button', {
+              name: 'adjective'
+            })
           );
         });
         isAdjectiveCategorySelected = true;
@@ -91,7 +110,8 @@ describe('Filtering', () => {
         });
       });
 
-      const expectedWordsNotVisible = entries.map(({ word }) => word.text)
+      const expectedWordsNotVisible = entries
+        .map(({ word }) => word.text)
         .filter(word => !expectedVisibleWords.includes(word));
       test.each(expectedWordsNotVisible)('word "%s" is not visible', async word => {
         await waitFor(() => {
@@ -100,8 +120,12 @@ describe('Filtering', () => {
       });
 
       test('open-filters button is checked', async () => {
-        await waitFor(() => expect(screen.getByTestId('open-filters-button-checked')).toBeOnTheScreen());
-        await waitFor(() => expect(screen.queryByTestId('open-filters-button-unchecked')).toBeNull());
+        await waitFor(() =>
+          expect(screen.getByTestId('open-filters-button-checked')).toBeOnTheScreen()
+        );
+        await waitFor(() =>
+          expect(screen.queryByTestId('open-filters-button-unchecked')).toBeNull()
+        );
       });
     });
 
@@ -111,8 +135,7 @@ describe('Filtering', () => {
         if (isAnatomyCategorySelected) return;
         await waitFor(() => {
           fireEvent.press(
-            within(screen.getByTestId('filters-container'))
-              .getByRole('button', { name: 'anatomy' })
+            within(screen.getByTestId('filters-container')).getByRole('button', { name: 'anatomy' })
           );
         });
         isAnatomyCategorySelected = true;
@@ -124,7 +147,8 @@ describe('Filtering', () => {
         });
       });
 
-      const expectedWordsNotVisible = entries.map(({ word }) => word.text)
+      const expectedWordsNotVisible = entries
+        .map(({ word }) => word.text)
         .filter(word => word !== 'arterial');
       test.each(expectedWordsNotVisible)('word "%s" is not visible', async word => {
         await waitFor(() => {
@@ -134,13 +158,22 @@ describe('Filtering', () => {
 
       describe('after deselecting "anatomy" category', () => {
         let anatomyIsDeselected;
-        const expectedVisibleWords = ['constructive', 'arterial', 'honourable', 'admirable', 'disorderly', 'foolish', 'understated'];
+        const expectedVisibleWords = [
+          'constructive',
+          'arterial',
+          'honourable',
+          'admirable',
+          'disorderly',
+          'foolish',
+          'understated'
+        ];
         beforeEach(async () => {
           if (anatomyIsDeselected) return;
           await waitFor(() => {
             fireEvent.press(
-              within(screen.getByTestId('filters-container'))
-                .getByRole('button', { name: 'anatomy' })
+              within(screen.getByTestId('filters-container')).getByRole('button', {
+                name: 'anatomy'
+              })
             );
           });
           anatomyIsDeselected = true;
@@ -152,7 +185,8 @@ describe('Filtering', () => {
           });
         });
 
-        const expectedWordsNotVisible = entries.map(({ word }) => word.text)
+        const expectedWordsNotVisible = entries
+          .map(({ word }) => word.text)
           .filter(word => !expectedVisibleWords.includes(word));
         test.each(expectedWordsNotVisible)('word "%s" is not visible', async word => {
           await waitFor(() => {
@@ -168,13 +202,11 @@ describe('Filtering', () => {
         if (areCategoriesSelected) return;
         await waitFor(() => {
           fireEvent.press(
-            within(screen.getByTestId('filters-container'))
-              .getByRole('button', { name: 'anatomy' })
+            within(screen.getByTestId('filters-container')).getByRole('button', { name: 'anatomy' })
           );
 
           fireEvent.press(
-            within(screen.getByTestId('filters-container'))
-              .getByRole('button', { name: 'food' })
+            within(screen.getByTestId('filters-container')).getByRole('button', { name: 'food' })
           );
         });
         areCategoriesSelected = true;
@@ -198,8 +230,7 @@ describe('Filtering', () => {
           if (foodIsDeselected) return;
           await waitFor(() => {
             fireEvent.press(
-              within(screen.getByTestId('filters-container'))
-                .getByRole('button', { name: 'food' })
+              within(screen.getByTestId('filters-container')).getByRole('button', { name: 'food' })
             );
           });
           foodIsDeselected = true;
@@ -223,7 +254,9 @@ describe('Filtering', () => {
       test('filters drawer is closed', async () => {
         const filtersContainer = screen.getByTestId('filters-container');
         fireEvent(filtersContainer, 'onClose');
-        await waitFor(() => expect(screen.queryByText('Select categories to include:')).not.toBeOnTheScreen());
+        await waitFor(() =>
+          expect(screen.queryByText('Select categories to include:')).not.toBeOnTheScreen()
+        );
       });
     });
   });

--- a/__tests__/journeys/AddWordlistEntryJourney.test.js
+++ b/__tests__/journeys/AddWordlistEntryJourney.test.js
@@ -3,7 +3,6 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { MockedProvider } from '@apollo/client/testing';
 import { NavigationContainer } from '@react-navigation/native';
-import { NotificationProvider } from '../../src/components';
 import { Provider as PaperProvider } from 'react-native-paper';
 import { CreateWordlistEntriesScreen, HomeScreen } from '../../src/screens';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react-native';
@@ -32,22 +31,20 @@ describe('Add Wordlist Entry journey', () => {
       render(
         <PaperProvider>
           <MockedProvider addTypename={true} mocks={[myWordlistQueryMock, mutationMock]}>
-            <NotificationProvider>
-              <NavigationContainer>
-                <Stack.Navigator>
-                  <Stack.Screen
-                    component={HomeScreen}
-                    name='Home'
-                    options={{ title: 'My Wordlist' }}
-                  />
-                  <Stack.Screen
-                    component={CreateWordlistEntriesScreen}
-                    name='CreateWordlistEntries'
-                    options={{ headerShown: false }}
-                  />
-                </Stack.Navigator>
-              </NavigationContainer>
-            </NotificationProvider>
+            <NavigationContainer>
+              <Stack.Navigator>
+                <Stack.Screen
+                  component={HomeScreen}
+                  name='Home'
+                  options={{ title: 'My Wordlist' }}
+                />
+                <Stack.Screen
+                  component={CreateWordlistEntriesScreen}
+                  name='CreateWordlistEntries'
+                  options={{ headerShown: false }}
+                />
+              </Stack.Navigator>
+            </NavigationContainer>
           </MockedProvider>
         </PaperProvider>
       );

--- a/__tests__/journeys/EditWordlistEntryJourney.test.js
+++ b/__tests__/journeys/EditWordlistEntryJourney.test.js
@@ -5,7 +5,6 @@ import { GraphQLError } from 'graphql';
 import { InMemoryCache } from '@apollo/client';
 import { MockedProvider } from '@apollo/client/testing';
 import { NavigationContainer } from '@react-navigation/native';
-import { NotificationProvider } from '../../src/components';
 import { Provider as PaperProvider } from 'react-native-paper';
 import { EditWordlistEntryScreen, HomeScreen } from '../../src/screens';
 import {
@@ -65,22 +64,20 @@ describe('Edit Wordlist Entry journey', () => {
               )
             ]}
           >
-            <NotificationProvider>
-              <NavigationContainer>
-                <Stack.Navigator>
-                  <Stack.Screen
-                    component={HomeScreen}
-                    name='Home'
-                    options={{ title: 'My Wordlist' }}
-                  />
-                  <Stack.Screen
-                    component={EditWordlistEntryScreen}
-                    name='EditWordlistEntry'
-                    options={{ headerShown: false }}
-                  />
-                </Stack.Navigator>
-              </NavigationContainer>
-            </NotificationProvider>
+            <NavigationContainer>
+              <Stack.Navigator>
+                <Stack.Screen
+                  component={HomeScreen}
+                  name='Home'
+                  options={{ title: 'My Wordlist' }}
+                />
+                <Stack.Screen
+                  component={EditWordlistEntryScreen}
+                  name='EditWordlistEntry'
+                  options={{ headerShown: false }}
+                />
+              </Stack.Navigator>
+            </NavigationContainer>
           </MockedProvider>
         </PaperProvider>
       );

--- a/__tests__/journeys/ForgottenPasswordJourney.test.js
+++ b/__tests__/journeys/ForgottenPasswordJourney.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { MockedProvider } from '@apollo/client/testing';
 import { NavigationContainer } from '@react-navigation/native';
-import { NotificationProvider } from '../../src/components';
 import { Provider as PaperProvider } from 'react-native-paper';
 import { ForgotYourPasswordScreen, LogInScreen } from '../../src/screens';
 import { render, screen, userEvent, waitFor } from '@testing-library/react-native';
@@ -24,22 +23,20 @@ describe('Forgotten Password Journey', () => {
     render(
       <PaperProvider>
         <MockedProvider>
-          <NotificationProvider>
-            <NavigationContainer>
-              <Stack.Navigator>
-                <Stack.Screen
-                  component={LogInScreen}
-                  name='LogIn'
-                  options={{ title: 'My Wordlist' }}
-                />
-                <Stack.Screen
-                  component={ForgotYourPasswordScreen}
-                  name='ForgotYourPassword'
-                  options={{ title: 'My Wordlist' }}
-                />
-              </Stack.Navigator>
-            </NavigationContainer>
-          </NotificationProvider>
+          <NavigationContainer>
+            <Stack.Navigator>
+              <Stack.Screen
+                component={LogInScreen}
+                name='LogIn'
+                options={{ title: 'My Wordlist' }}
+              />
+              <Stack.Screen
+                component={ForgotYourPasswordScreen}
+                name='ForgotYourPassword'
+                options={{ title: 'My Wordlist' }}
+              />
+            </Stack.Navigator>
+          </NavigationContainer>
         </MockedProvider>
       </PaperProvider>
     );

--- a/__tests__/journeys/GenerateExampleSentencesJourney.test.js
+++ b/__tests__/journeys/GenerateExampleSentencesJourney.test.js
@@ -3,7 +3,6 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { MockedProvider } from '@apollo/client/testing';
 import { NavigationContainer } from '@react-navigation/native';
-import { NotificationProvider } from '../../src/components';
 import { Provider as PaperProvider } from 'react-native-paper';
 import { when } from 'jest-when';
 import { fetchOrCreateExampleSentences, myWordlistQueryMock } from '../../mockedProviderMocks';
@@ -30,22 +29,20 @@ describe('Generate Example Sentences journey', () => {
               fetchOrCreateExampleSentences.C1
             ]}
           >
-            <NotificationProvider>
-              <NavigationContainer>
-                <Stack.Navigator>
-                  <Stack.Screen
-                    component={HomeScreen}
-                    name='Home'
-                    options={{ title: 'My Wordlist' }}
-                  />
-                  <Stack.Screen
-                    component={GenerateExampleSentencesScreen}
-                    name='GenerateExampleSentences'
-                    options={{ title: 'Generate Example Sentences' }}
-                  />
-                </Stack.Navigator>
-              </NavigationContainer>
-            </NotificationProvider>
+            <NavigationContainer>
+              <Stack.Navigator>
+                <Stack.Screen
+                  component={HomeScreen}
+                  name='Home'
+                  options={{ title: 'My Wordlist' }}
+                />
+                <Stack.Screen
+                  component={GenerateExampleSentencesScreen}
+                  name='GenerateExampleSentences'
+                  options={{ title: 'Generate Example Sentences' }}
+                />
+              </Stack.Navigator>
+            </NavigationContainer>
           </MockedProvider>
         </PaperProvider>
       );

--- a/__tests__/journeys/GenerateExampleSentencesWithExplanationsJourney.test.js
+++ b/__tests__/journeys/GenerateExampleSentencesWithExplanationsJourney.test.js
@@ -3,7 +3,6 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { MockedProvider } from '@apollo/client/testing';
 import { NavigationContainer } from '@react-navigation/native';
-import { NotificationProvider } from '../../src/components';
 import { Provider as PaperProvider } from 'react-native-paper';
 import { when } from 'jest-when';
 import {
@@ -16,7 +15,7 @@ import { GenerateExampleSentencesScreen, HomeScreen } from '../../src/screens';
 
 jest.useFakeTimers();
 
-describe('Generate Example Sentences journey', () => {
+describe('Generate Example Sentences With Explanations journey', () => {
   beforeEach(async () => {
     when(AsyncStorage.getItem)
       .calledWith('myWordlistAuthToken')
@@ -34,22 +33,20 @@ describe('Generate Example Sentences journey', () => {
               fetchOrCreateExampleSentencesWithExplanations.B1Italian
             ]}
           >
-            <NotificationProvider>
-              <NavigationContainer>
-                <Stack.Navigator>
-                  <Stack.Screen
-                    component={HomeScreen}
-                    name='Home'
-                    options={{ title: 'My Wordlist' }}
-                  />
-                  <Stack.Screen
-                    component={GenerateExampleSentencesScreen}
-                    name='GenerateExampleSentences'
-                    options={{ title: 'Generate Example Sentences' }}
-                  />
-                </Stack.Navigator>
-              </NavigationContainer>
-            </NotificationProvider>
+            <NavigationContainer>
+              <Stack.Navigator>
+                <Stack.Screen
+                  component={HomeScreen}
+                  name='Home'
+                  options={{ title: 'My Wordlist' }}
+                />
+                <Stack.Screen
+                  component={GenerateExampleSentencesScreen}
+                  name='GenerateExampleSentences'
+                  options={{ title: 'Generate Example Sentences' }}
+                />
+              </Stack.Navigator>
+            </NavigationContainer>
           </MockedProvider>
         </PaperProvider>
       );

--- a/__tests__/screens/EditWordlistEntryScreen.test.js
+++ b/__tests__/screens/EditWordlistEntryScreen.test.js
@@ -4,6 +4,7 @@ import { EditWordlistEntryScreen } from '../../src/screens';
 import { MockedProvider } from '@apollo/client/testing';
 import { myWordlistQueryMock } from '../../mockedProviderMocks';
 import { NavigationContainer } from '@react-navigation/native';
+import { PaperProvider } from 'react-native-paper';
 import { useQuery } from '@apollo/client';
 import { render, screen, waitFor } from '@testing-library/react-native';
 
@@ -36,11 +37,13 @@ describe('EditWordlistEntryScreen', () => {
     useQuery.mockImplementation(() => myWordlistQueryMock.result);
     await waitFor(() => {
       render(
-        <NavigationContainer>
-          <MockedProvider>
-            <EditWordlistEntryScreen navigation={{ navigate: jest.fn() }} />
-          </MockedProvider>
-        </NavigationContainer>
+        <PaperProvider>
+          <NavigationContainer>
+            <MockedProvider>
+              <EditWordlistEntryScreen navigation={{ navigate: jest.fn() }} />
+            </MockedProvider>
+          </NavigationContainer>
+        </PaperProvider>
       );
     });
   });

--- a/__tests__/screens/HomeScreen.test.js
+++ b/__tests__/screens/HomeScreen.test.js
@@ -1,13 +1,22 @@
 import * as React from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { HomeScreen } from '../../src/screens';
 import { MockedProvider } from '@apollo/client/testing';
 import { NavigationContainer } from '@react-navigation/native';
 import { Provider as PaperProvider } from 'react-native-paper';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
-import { myWordlistQueryMock, myWordlistQueryMockWithOneEntry } from '../../mockedProviderMocks/my-wordlist';
+import {
+  myWordlistQueryMock,
+  myWordlistQueryMockWithOneEntry
+} from '../../mockedProviderMocks/my-wordlist';
 
 jest.useFakeTimers();
+
+const HomeScreenWrapper = navigation => {
+  const WrappedHomeScreen = () => <HomeScreen navigation={navigation} />;
+  return WrappedHomeScreen;
+};
 
 const mockNavigation = { navigate: jest.fn() };
 
@@ -15,21 +24,29 @@ describe('HomeScreen', () => {
   afterEach(() => jest.clearAllMocks());
 
   describe('when no auth token in storage', () => {
-    beforeEach(() => {
-      render(
-        <NavigationContainer>
-          <MockedProvider addTypename mocks={[myWordlistQueryMock]}>
-            <HomeScreen navigation={mockNavigation} />
-          </MockedProvider>
-        </NavigationContainer>
-      );
+    beforeEach(async () => {
+      const Stack = createNativeStackNavigator();
+      await waitFor(() => {
+        render(
+          <PaperProvider>
+            <NavigationContainer>
+              <MockedProvider addTypename mocks={[myWordlistQueryMock]}>
+                <Stack.Navigator>
+                  <Stack.Screen component={HomeScreenWrapper(mockNavigation)} name='Home' />
+                </Stack.Navigator>
+              </MockedProvider>
+            </NavigationContainer>
+          </PaperProvider>
+        );
+      });
     });
 
     test('calls navigate() once', () => {
       expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
     });
 
-    test('calls navigate() with \'LogIn\'', () => {
+    // eslint-disable-next-line quotes
+    test("calls navigate() with 'LogIn'", () => {
       expect(mockNavigation.navigate).toHaveBeenCalledWith('LogIn');
     });
 
@@ -50,11 +67,14 @@ describe('HomeScreen', () => {
       });
 
       await waitFor(() => {
+        const Stack = createNativeStackNavigator();
         render(
           <PaperProvider>
             <NavigationContainer>
               <MockedProvider addTypename={true} mocks={[myWordlistQueryMockWithOneEntry]}>
-                <HomeScreen navigation={mockNavigation} />
+                <Stack.Navigator>
+                  <Stack.Screen component={HomeScreenWrapper(mockNavigation)} name='Home' />
+                </Stack.Navigator>
               </MockedProvider>
             </NavigationContainer>
           </PaperProvider>
@@ -77,36 +97,22 @@ describe('HomeScreen', () => {
         expect(screen.getByText(name)).toBeOnTheScreen();
       });
     });
-  });
 
-  describe('Pressing FAB (+ sign) button', () => {
-    beforeEach(async () => {
-      await waitFor(() => {
-        render(
-          <PaperProvider>
-            <NavigationContainer>
-              <MockedProvider addTypename={true} mocks={[myWordlistQueryMock]}>
-                <HomeScreen navigation={mockNavigation} />
-              </MockedProvider>
-            </NavigationContainer>
-          </PaperProvider>
-        );
+    describe('pressing FAB (+ sign) button', () => {
+      beforeEach(async () => await waitFor(() => fireEvent.press(screen.getByTestId('fab'))));
+
+      test('calls navigate() once', async () => {
+        await waitFor(() => {
+          expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
+        });
       });
 
-      await waitFor(() => {
-        fireEvent.press(screen.getByTestId('fab'));
-      });
-    });
-
-    test('calls navigate() once', async () => {
-      await waitFor(() => {
-        expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    test('calls navigate() with CreateWordlistEntries', async () => {
-      await waitFor(() => {
-        expect(mockNavigation.navigate).toHaveBeenCalledWith('CreateWordlistEntries', { wordlistId: 'c722b3ef-c762-4245-a0fa-fb452c4539cf' });
+      test('calls navigate() with CreateWordlistEntries and expected wordlistId', async () => {
+        await waitFor(() => {
+          expect(mockNavigation.navigate).toHaveBeenCalledWith('CreateWordlistEntries', {
+            wordlistId: 'c722b3ef-c762-4245-a0fa-fb452c4539cf'
+          });
+        });
       });
     });
   });

--- a/__tests__/screens/HomeScreen.test.js
+++ b/__tests__/screens/HomeScreen.test.js
@@ -14,8 +14,9 @@ import {
 jest.useFakeTimers();
 
 const HomeScreenWrapper = navigation => {
-  const WrappedHomeScreen = () => <HomeScreen navigation={navigation} />;
-  return WrappedHomeScreen;
+  return function HomeScreenWrapper() {
+    return <HomeScreen navigation={navigation} />;
+  };
 };
 
 const mockNavigation = { navigate: jest.fn() };

--- a/__tests__/screens/LogInScreen.test.js
+++ b/__tests__/screens/LogInScreen.test.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { LogInScreen } from '../../src/screens';
 import { MockedProvider } from '@apollo/client/testing';
 import { NavigationContainer } from '@react-navigation/native';
@@ -6,14 +7,23 @@ import { render, screen, userEvent, waitFor } from '@testing-library/react-nativ
 
 jest.useFakeTimers();
 
+const LoginScreenWrapper = navigation => {
+  return function LoginScreenWrapper() {
+    return <LogInScreen navigation={navigation} />;
+  };
+};
+
 const mockNavigation = { navigate: jest.fn() };
 
 describe('LogInScreen', () => {
   beforeEach(() => {
+    const Stack = createNativeStackNavigator();
     render(
       <NavigationContainer>
         <MockedProvider>
-          <LogInScreen navigation={mockNavigation} />
+          <Stack.Navigator>
+            <Stack.Screen component={LoginScreenWrapper(mockNavigation)} name='LogIn' />
+          </Stack.Navigator>
         </MockedProvider>
       </NavigationContainer>
     );
@@ -48,12 +58,16 @@ describe('LogInScreen', () => {
   });
 
   test('displays navigate to sign up text', async () => {
-    await waitFor(() => expect(screen.getByRole('button', { name: 'New user? Sign up' })).toBeOnTheScreen());
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'New user? Sign up' })).toBeOnTheScreen()
+    );
   });
 
   describe('if user taps the sign-up button', () => {
     beforeEach(async () => {
-      const signUpButton = await waitFor(() => screen.getByRole('button', { name: 'New user? Sign up' }));
+      const signUpButton = await waitFor(() =>
+        screen.getByRole('button', { name: 'New user? Sign up' })
+      );
       const user = userEvent.setup();
       await user.press(signUpButton);
     });

--- a/src/components/GenerateExampleSentencesScreenWrapper.tsx
+++ b/src/components/GenerateExampleSentencesScreenWrapper.tsx
@@ -1,7 +1,6 @@
 import { GenerateExampleSentencesOptionsContext } from '../contexts';
-import sharedStyles from '../styles';
 import { useRoute } from '@react-navigation/native';
-import { ExampleSentences, Loading, SentencesGeneratorOptions } from '../components';
+import { ExampleSentences, Loading, ScreenWrapper, SentencesGeneratorOptions } from '../components';
 import { Explanation, Level } from '../__generated__/graphql';
 import {
   GenerateExampleSentencesOptionsContextType,
@@ -100,7 +99,7 @@ export const GenerateExampleSentencesScreenWrapper = () => {
   };
 
   return (
-    <View style={{ ...sharedStyles.container, justifyContent: 'flex-start' }}>
+    <ScreenWrapper additionalStyles={{ justifyContent: 'flex-start' }}>
       <SentencesGeneratorOptions />
       {loading ? (
         <View style={{ marginTop: 80 }}>
@@ -120,6 +119,6 @@ export const GenerateExampleSentencesScreenWrapper = () => {
           </View>
         </ScrollView>
       )}
-    </View>
+    </ScreenWrapper>
   );
 };

--- a/src/components/NotificationProvider.tsx
+++ b/src/components/NotificationProvider.tsx
@@ -1,11 +1,18 @@
 import { snackbarStateVar } from '../reactiveVars';
 import { useReactiveVar } from '@apollo/client';
+import { useRoute } from '@react-navigation/native';
 import { useSnackbar } from '../hooks';
-import { EmitterSubscription, Keyboard, Platform, StyleSheet, View } from 'react-native';
+import { EmitterSubscription, Keyboard, Platform } from 'react-native';
+import { ReactNode, useEffect, useState } from 'react';
 import { Snackbar, useTheme } from 'react-native-paper';
-import { useEffect, useState } from 'react';
 
-export const NotificationProvider = ({ children }: { children: React.ReactElement }) => {
+const useIsModal = () => {
+  const route = useRoute();
+  const { presentation } = route.params || {};
+  return presentation === 'modal';
+};
+
+export const NotificationProvider = ({ children }: { children: ReactNode }) => {
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const { hideSnackbar } = useSnackbar();
   const {
@@ -13,6 +20,7 @@ export const NotificationProvider = ({ children }: { children: React.ReactElemen
   } = useTheme();
 
   const { duration, error, key, message, visible } = useReactiveVar(snackbarStateVar);
+  const isModal = useIsModal();
 
   useEffect(() => {
     let keyboardDidShowListener: EmitterSubscription;
@@ -33,27 +41,19 @@ export const NotificationProvider = ({ children }: { children: React.ReactElemen
   }, []);
 
   const backgroundColor = error ? errorColour : primary;
+
   return (
     <>
       {children}
-      <View style={styles.snackbarWrapper}>
-        <Snackbar
-          duration={duration}
-          key={key}
-          onDismiss={() => hideSnackbar()}
-          style={{ backgroundColor, marginBottom: keyboardHeight }}
-          visible={visible}
-        >
-          {message}
-        </Snackbar>
-      </View>
+      <Snackbar
+        duration={duration}
+        key={key}
+        onDismiss={() => hideSnackbar()}
+        style={{ backgroundColor, marginBottom: keyboardHeight + 7 + (isModal ? 20 : 0) }}
+        visible={visible}
+      >
+        {message}
+      </Snackbar>
     </>
   );
 };
-
-const styles = StyleSheet.create({
-  snackbarWrapper: {
-    marginBottom: 7,
-    marginTop: 'auto'
-  }
-});

--- a/src/components/NotificationProvider.tsx
+++ b/src/components/NotificationProvider.tsx
@@ -6,8 +6,14 @@ import { EmitterSubscription, Keyboard, Platform } from 'react-native';
 import { ReactNode, useEffect, useState } from 'react';
 import { Snackbar, useTheme } from 'react-native-paper';
 
+type Route = {
+  params?: {
+    presentation?: string;
+  };
+};
+
 const useIsModal = () => {
-  const route = useRoute();
+  const route: Route = useRoute();
   const { presentation } = route.params || {};
   return presentation === 'modal';
 };
@@ -27,7 +33,7 @@ export const NotificationProvider = ({ children }: { children: ReactNode }) => {
     let keyboardDidHideListener: EmitterSubscription;
     if (Platform.OS === 'ios') {
       keyboardDidShowListener = Keyboard.addListener('keyboardWillShow', ({ endCoordinates }) =>
-        setKeyboardHeight(endCoordinates.height - 30)
+        setKeyboardHeight(endCoordinates.height)
       );
       keyboardDidHideListener = Keyboard.addListener('keyboardWillHide', () =>
         setKeyboardHeight(0)

--- a/src/components/NotificationProvider.tsx
+++ b/src/components/NotificationProvider.tsx
@@ -47,6 +47,7 @@ export const NotificationProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   const backgroundColor = error ? errorColour : primary;
+  const marginBottom = keyboardHeight + 7 + (isModal && Platform.OS === 'ios' ? 20 : 0);
 
   return (
     <>
@@ -55,7 +56,7 @@ export const NotificationProvider = ({ children }: { children: ReactNode }) => {
         duration={duration}
         key={key}
         onDismiss={() => hideSnackbar()}
-        style={{ backgroundColor, marginBottom: keyboardHeight + 7 + (isModal ? 20 : 0) }}
+        style={{ backgroundColor, marginBottom }}
         visible={visible}
       >
         {message}

--- a/src/components/NotificationProvider.tsx
+++ b/src/components/NotificationProvider.tsx
@@ -8,14 +8,14 @@ import { Snackbar, useTheme } from 'react-native-paper';
 
 type Route = {
   params?: {
-    presentation?: string;
+    isModal?: boolean;
   };
 };
 
 const useIsModal = () => {
   const route: Route = useRoute();
-  const { presentation } = route.params || {};
-  return presentation === 'modal';
+  const { isModal } = route.params || {};
+  return Boolean(isModal);
 };
 
 export const NotificationProvider = ({ children }: { children: ReactNode }) => {

--- a/src/components/ScreenWrapper.tsx
+++ b/src/components/ScreenWrapper.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+import sharedStyles from '../styles';
+import { StyleProp, View, ViewStyle } from 'react-native';
+
+export const ScreenWrapper = ({
+  additionalStyles,
+  children
+}: {
+  additionalStyles?: StyleProp<ViewStyle>;
+  children: ReactNode;
+}) => {
+  return <View style={[sharedStyles.container, additionalStyles]}>{children}</View>;
+};

--- a/src/components/ScreenWrapper.tsx
+++ b/src/components/ScreenWrapper.tsx
@@ -1,3 +1,4 @@
+import { NotificationProvider } from './NotificationProvider';
 import { ReactNode } from 'react';
 import sharedStyles from '../styles';
 import { StyleProp, View, ViewStyle } from 'react-native';
@@ -9,5 +10,9 @@ export const ScreenWrapper = ({
   additionalStyles?: StyleProp<ViewStyle>;
   children: ReactNode;
 }) => {
-  return <View style={[sharedStyles.container, additionalStyles]}>{children}</View>;
+  return (
+    <NotificationProvider>
+      <View style={[sharedStyles.container, additionalStyles]}>{children}</View>
+    </NotificationProvider>
+  );
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,5 +10,6 @@ export { GenerateExampleSentencesScreenWrapper } from './GenerateExampleSentence
 export { Loading } from './Loading';
 export { NavigationBar } from './NavigationBar';
 export { NotificationProvider } from './NotificationProvider';
+export { ScreenWrapper } from './ScreenWrapper';
 export { SentencesGeneratorOptions } from './SentencesGeneratorOptions';
 export { Wordlist } from './Wordlist';

--- a/src/screens/CreateWordlistEntriesScreen.tsx
+++ b/src/screens/CreateWordlistEntriesScreen.tsx
@@ -1,12 +1,11 @@
 import { CreateWordlistEntriesScreenProps } from '../../types';
-import { CreateWordlistEntryForm } from '../components';
-import sharedStyles from '../styles';
+import { CreateWordlistEntryForm, ScreenWrapper } from '../components';
 import { IconButton, Text } from 'react-native-paper';
-import { Platform, StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 export const CreateWordlistEntriesScreen = ({ navigation }: CreateWordlistEntriesScreenProps) => {
   return (
-    <View style={{ ...sharedStyles.container, ...styles.wrapper }}>
+    <ScreenWrapper additionalStyles={styles.wrapper}>
       <Text style={styles.title}>Add Word</Text>
       <IconButton
         aria-label='close'
@@ -16,7 +15,7 @@ export const CreateWordlistEntriesScreen = ({ navigation }: CreateWordlistEntrie
         testID='close-create-wordlist-entries-screen-icon-button'
       />
       <CreateWordlistEntryForm />
-    </View>
+    </ScreenWrapper>
   );
 };
 

--- a/src/screens/EditWordlistEntryScreen.tsx
+++ b/src/screens/EditWordlistEntryScreen.tsx
@@ -1,11 +1,10 @@
 import { MY_WORDLIST } from '../graphql-queries';
 import { parseUniqueCategories } from '../utils';
 import React from 'react';
-import sharedStyles from '../styles';
 import { useAsyncStorage } from '../hooks';
 import { useRoute } from '@react-navigation/native';
 import { useState } from 'react';
-import { AddCategoriesForm, EditWordForm } from '../components';
+import { AddCategoriesForm, EditWordForm, ScreenWrapper } from '../components';
 import { Button, Chip, Divider, IconButton, Text } from 'react-native-paper';
 import { Category, MyWordlist, WordlistEntry } from '../__generated__/graphql';
 import { EditWordlistEntryScreenProps, EditWordlistEntryScreenRouteParams } from '../../types';
@@ -165,7 +164,7 @@ export const EditWordlistEntryScreen = ({
   };
 
   return (
-    <View style={{ ...sharedStyles.container, ...styles.wrapper }}>
+    <ScreenWrapper additionalStyles={styles.wrapper}>
       <Text style={styles.title}>Edit</Text>
       {editWordFormVisible ? (
         <Button
@@ -198,7 +197,7 @@ export const EditWordlistEntryScreen = ({
         entryCategories={categories}
         wordlistEntryToUpdate={wordlistEntry}
       />
-    </View>
+    </ScreenWrapper>
   );
 };
 

--- a/src/screens/ForgotYourPasswordScreen.tsx
+++ b/src/screens/ForgotYourPasswordScreen.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { RESET_PASSWORD_URL } from '@env';
 import { ScreenWrapper } from '../components';
-import sharedStyles from '../styles';
 import { useSnackbar } from '../hooks';
 import { Button, Paragraph, TextInput } from 'react-native-paper';
 import { Keyboard, KeyboardAvoidingView, StyleSheet } from 'react-native';

--- a/src/screens/ForgotYourPasswordScreen.tsx
+++ b/src/screens/ForgotYourPasswordScreen.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { RESET_PASSWORD_URL } from '@env';
+import { ScreenWrapper } from '../components';
 import sharedStyles from '../styles';
 import { useSnackbar } from '../hooks';
 import { Button, Paragraph, TextInput } from 'react-native-paper';
@@ -46,32 +47,34 @@ export const ForgotYourPasswordScreen = () => {
   };
 
   return (
-    <KeyboardAvoidingView behavior='padding' style={{ ...sharedStyles.container, padding: 40 }}>
-      <Paragraph style={{ marginBottom: 16 }}>
-        Please enter your email address below and we&apos;ll send you a reset link.
-      </Paragraph>
-      <TextInput
-        autoCapitalize='none'
-        keyboardType='email-address'
-        label='Email'
-        mode='outlined'
-        onChangeText={setEmail}
-        onSubmitEditing={handleSubmit}
-        returnKeyType='send'
-        style={{ marginBottom: error ? 0 : 24 }}
-        testID='email-input-field'
-        value={email}
-      />
-      {error ? <Paragraph style={styles.errorText}>{error}</Paragraph> : null}
-      <Button
-        loading={loading}
-        mode='contained'
-        onPress={handleSubmit}
-        style={{ marginBottom: 16 }}
-      >
-        Submit
-      </Button>
-    </KeyboardAvoidingView>
+    <ScreenWrapper additionalStyles={{ padding: 40 }}>
+      <KeyboardAvoidingView behavior='padding'>
+        <Paragraph style={{ marginBottom: 16 }}>
+          Please enter your email address below and we&apos;ll send you a reset link.
+        </Paragraph>
+        <TextInput
+          autoCapitalize='none'
+          keyboardType='email-address'
+          label='Email'
+          mode='outlined'
+          onChangeText={setEmail}
+          onSubmitEditing={handleSubmit}
+          returnKeyType='send'
+          style={{ marginBottom: error ? 0 : 24 }}
+          testID='email-input-field'
+          value={email}
+        />
+        {error ? <Paragraph style={styles.errorText}>{error}</Paragraph> : null}
+        <Button
+          loading={loading}
+          mode='contained'
+          onPress={handleSubmit}
+          style={{ marginBottom: 16 }}
+        >
+          Submit
+        </Button>
+      </KeyboardAvoidingView>
+    </ScreenWrapper>
   );
 };
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,8 +1,8 @@
 import { Drawer } from 'react-native-drawer-layout';
 import type { HomeScreenProps } from '../../types';
 import React from 'react';
+import { ScreenWrapper } from '../components';
 import { selectedCategoriesIdsVar } from '../reactiveVars';
-import sharedStyles from '../styles';
 import { useFetchWordlistData } from '../hooks';
 import { useReactiveVar } from '@apollo/client';
 import { useState } from 'react';
@@ -26,7 +26,7 @@ export const HomeScreen = ({ navigation }: HomeScreenProps) => {
       open={open}
       renderDrawerContent={() => myWordlist && <Filters />}
     >
-      <View style={{ ...sharedStyles.container, justifyContent, padding: 15 }}>
+      <ScreenWrapper additionalStyles={{ justifyContent, padding: 15 }}>
         {loading && <Loading size='large' />}
         {myWordlist && (
           <>
@@ -52,7 +52,7 @@ export const HomeScreen = ({ navigation }: HomeScreenProps) => {
             />
           </>
         )}
-      </View>
+      </ScreenWrapper>
     </Drawer>
   );
 };

--- a/src/screens/LogInScreen.tsx
+++ b/src/screens/LogInScreen.tsx
@@ -1,13 +1,12 @@
 import { EyeIcon } from '../components';
 import type { LogInScreenProps } from '../../types';
-import sharedStyles from '../styles';
+import { ScreenWrapper } from '../components';
+import { StyleSheet } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
-import { useState } from 'react';
 import { ApolloClient, NormalizedCacheObject, useApolloClient } from '@apollo/client';
 import { Button, HelperText, TextInput } from 'react-native-paper';
 import { isInvalidEmail, signIn } from '../utils';
-import React, { Dispatch, SetStateAction, useEffect } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
 const useInputValues = (
   email: string,
@@ -56,7 +55,7 @@ export const LogInScreen = ({ navigation }: LogInScreenProps) => {
   };
 
   return (
-    <View style={{ ...sharedStyles.container, padding: 40 }}>
+    <ScreenWrapper additionalStyles={{ padding: 40 }}>
       <TextInput
         aria-label='email'
         autoCapitalize='none'
@@ -124,7 +123,7 @@ export const LogInScreen = ({ navigation }: LogInScreenProps) => {
       >
         Forgot your password?
       </Button>
-    </View>
+    </ScreenWrapper>
   );
 };
 

--- a/src/screens/SignUpScreen.tsx
+++ b/src/screens/SignUpScreen.tsx
@@ -1,10 +1,9 @@
-import { EyeIcon } from '../components';
 import { MY_WORDLIST_CREATE } from '../graphql-queries/myWordlistCreate';
-import sharedStyles from '../styles';
 import type { SignUpScreenProps } from '../../types';
+import { StyleSheet } from 'react-native';
 import { Button, HelperText, TextInput } from 'react-native-paper';
+import { EyeIcon, ScreenWrapper } from '../components';
 import { isInvalidEmail, signUp } from '../utils';
-import { StyleSheet, View } from 'react-native';
 import { useApolloClient, useMutation } from '@apollo/client';
 import { useEffect, useState } from 'react';
 
@@ -72,7 +71,7 @@ export const SignUpScreen = ({ navigation }: SignUpScreenProps) => {
   };
 
   return (
-    <View style={{ ...sharedStyles.container, padding: 40 }}>
+    <ScreenWrapper additionalStyles={{ padding: 40 }}>
       <TextInput
         aria-label='email'
         autoCapitalize='none'
@@ -125,7 +124,7 @@ export const SignUpScreen = ({ navigation }: SignUpScreenProps) => {
       >
         Have an account? Log in
       </Button>
-    </View>
+    </ScreenWrapper>
   );
 };
 

--- a/types.ts
+++ b/types.ts
@@ -5,8 +5,8 @@ import { Level, MyWordlist, NativeLanguage } from './src/__generated__/graphql';
 export type AuthToken = string | null;
 
 export type RootStackParamList = {
-  CreateWordlistEntries: { presentation: string; wordlistId: string };
-  EditWordlistEntry: { presentation: string; id: string };
+  CreateWordlistEntries: { presentation?: string; wordlistId: string };
+  EditWordlistEntry: { presentation?: string; id: string };
   ForgotYourPassword: undefined;
   GenerateExampleSentences: { wordId: string };
   Home: undefined;

--- a/types.ts
+++ b/types.ts
@@ -5,8 +5,8 @@ import { Level, MyWordlist, NativeLanguage } from './src/__generated__/graphql';
 export type AuthToken = string | null;
 
 export type RootStackParamList = {
-  CreateWordlistEntries: { presentation?: string; wordlistId: string };
-  EditWordlistEntry: { presentation?: string; id: string };
+  CreateWordlistEntries: { isModal?: boolean; wordlistId: string };
+  EditWordlistEntry: { id: string; isModal?: boolean };
   ForgotYourPassword: undefined;
   GenerateExampleSentences: { wordId: string };
   Home: undefined;

--- a/types.ts
+++ b/types.ts
@@ -5,8 +5,8 @@ import { Level, MyWordlist, NativeLanguage } from './src/__generated__/graphql';
 export type AuthToken = string | null;
 
 export type RootStackParamList = {
-  CreateWordlistEntries: { wordlistId: string };
-  EditWordlistEntry: { id: string };
+  CreateWordlistEntries: { presentation: string; wordlistId: string };
+  EditWordlistEntry: { presentation: string; id: string };
   ForgotYourPassword: undefined;
   GenerateExampleSentences: { wordId: string };
   Home: undefined;


### PR DESCRIPTION
Fixes bug where keyboard hides the snackbar notifications. When the Create and Edit screens were changed to modals (`{ presentation: 'modal' }`) the notifications were hidden 'beneath' the modals.

The `NotificationProvider` implementation meant the notifications were rendered as siblings of the modals and the modals would always render on top of the notifications, no matter what I tried.

Solution: Create a `ScreenWrapper` component which wraps each screen, including the modal screens - this means the notifications are part of each screen, so they render within that screen/modal, so always appear.

The only downside is that after closing a modal while it is showing a notification, that notification renders again on the next screen i.e. pops down and pops back up again. But it is not really a problem - the notification's state is shared and persists between screens via the reactive variable, so if only 2 seconds are remaining, that 2 seconds is not bumped back up to 5 seconds when the notification is rendered again, for example, and the animation all happens very quickly and is particularly jarring for the user.
